### PR TITLE
chore: Update jena to 4.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 ## This Dockefile builds a reduced footprint container.
 
 ARG ALPINE_VERSION=3.15.0
-ARG JENA_VERSION="4.6.1"
+ARG JENA_VERSION="4.7.0"
 ARG JVM_ARGS="-Xmx2048m -Xms2048m"
 
 # Internal, passed between stages.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ This project builds Docker image and a helm chart for chosen version of [Fuseki 
 ## Building docker image
 
 The Docker image building process takes the following arguments:
-`JENA_VERSION` defaulted to `4.6.1`
+`JENA_VERSION` defaulted to `4.7.0`
 `OPENJDK_VERSION` defaulted to `17`
 `ALPINE_VERSION` defaulted to `3.15.0`
 
 To build the Docker image manually the following command can be used:
 ```
-docker build --force-rm --build-arg JENA_VERSION=4.6.1 -t fuseki .
+docker build --force-rm --build-arg JENA_VERSION=4.7.0 -t fuseki .
 ```
 
 It's possible to build the image for `linux/amd64` and `linux/arm64` platforms.

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -13,4 +13,4 @@ charts:
         dockerfilePath: Dockerfile
         valuesPath: image
         buildArgs:
-          JENA_VERSION: "4.6.1"
+          JENA_VERSION: "4.7.0"

--- a/renku-jena/Chart.yaml
+++ b/renku-jena/Chart.yaml
@@ -15,10 +15,10 @@ description: A Helm chart for Kubernetes
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.18
+version: 0.0.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.6.1"
+appVersion: "4.7.0"

--- a/renku-jena/values.yaml
+++ b/renku-jena/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: renku/renku-jena
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: '0.0.18'
+  tag: '0.0.19'
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This PR updates Jena to the current 4.7.0 version.