### PR TITLE
fix: delete tdb.lock at startup if it exists

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,24 +1,32 @@
 #!/bin/sh
 ## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 
-if [ ! -f "$FUSEKI_BASE/config.ttl" ] ; then
+if [ ! -f "$FUSEKI_BASE/config.ttl" ]; then
   echo "###################################"
   echo "No server $FUSEKI_BASE/config.ttl -> copying default..."
   echo "###################################"
   cp "$FUSEKI_HOME/run/config.ttl" "$FUSEKI_BASE/config.ttl"
 fi
 
-if [ ! -f "$FUSEKI_BASE/shiro.ini" ] ; then
+if [ ! -f "$FUSEKI_BASE/shiro.ini" ]; then
   echo "###################################"
   echo "No $FUSEKI_BASE/shiro.ini -> copying default..."
   echo "###################################"
   cp "$FUSEKI_HOME/run/shiro.ini" "$FUSEKI_BASE/shiro.ini"
 fi
 
-cp ${FUSEKI_HOME}/run/log4j2.properties ${FUSEKI_BASE}/log4j2.properties
+cp "${FUSEKI_HOME}/run/log4j2.properties" "${FUSEKI_BASE}/log4j2.properties"
 
-if [[ ! -n "$FUSEKI_COMMAND" ]] ; then
+if [ -z "$FUSEKI_COMMAND" ]; then
   export FUSEKI_COMMAND="--conf=${FUSEKI_BASE}/config.ttl"
 fi
 
-exec /usr/bin/compact-jena & "${FUSEKI_HOME}/fuseki-server" "$FUSEKI_COMMAND"
+if [ -f "$FUSEKI_BASE/system/tdb.lock" ]; then
+  echo "###################################"
+  echo "Found an existing tdb.lock at startup at $FUSEKI_BASE/system, will delete it before startup."
+  echo "###################################"
+  rm -f "$FUSEKI_BASE/system/tdb.lock"
+fi
+
+exec /usr/bin/compact-jena &
+"${FUSEKI_HOME}/fuseki-server" "$FUSEKI_COMMAND"


### PR DESCRIPTION
Should fix this issue: 
https://github.com/SwissDataScienceCenter/renku/issues/3999

It seems that if the pod restarts it is possble that the lock is not cleaned up. Then at startup we things keep crashing because the lock is still there. This is mean to prevent multiple JVMs to use the db at the same time. But at startup there is n't any JVMs running at all. The lock just persists from a crash in persistent volume.

