### PR TITLE
chore(release): update versions to 0.0.26

### DIFF
--- a/renku-jena/Chart.yaml
+++ b/renku-jena/Chart.yaml
@@ -15,7 +15,7 @@ description: A Helm chart for Kubernetes
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.25
+version: 0.0.26
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/renku-jena/values.yaml
+++ b/renku-jena/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: renku/renku-jena
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: '0.0.25'
+  tag: '0.0.26'
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
According to the readme in the repo this is required to be done before a new release.

It is probably not necessary because chartpress  will update this automatically when it does the release. But I wanted to follow the instructions for the repo and not take any chances.